### PR TITLE
Setting to break long URLs in menu list items

### DIFF
--- a/flat/style/flat.css
+++ b/flat/style/flat.css
@@ -124,7 +124,7 @@ ul#doclist,ul#dirlist {
     color: black;
     min-height: 50px;
     list-style: none;
-    clear: both; 
+    clear: both;
 }
 ul#dirlist>li {
     font-weight: bold;
@@ -173,6 +173,8 @@ a:hover {
     padding: 5px;
     padding-left: 10px;
     padding-right: 10px;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 }
 #topbar nav li li {
     display: inline-block;
@@ -266,7 +268,7 @@ span.helptext {
 }
 #aborted {
     display: none;
-    margin-top: -100px; 
+    margin-top: -100px;
 }
 #aborted, #fatalerror {
     width: 50%;
@@ -321,7 +323,7 @@ div#leftpane .title {
     padding: 2px;
     margin: 5px;
     color: black;
-    clear: both; 
+    clear: both;
     font-size: 80%;
     padding-left: 30px;
     padding-bottom: 30px;


### PR DESCRIPTION
The long URLs for foliasets were not readable as it can be seen in the first screenshot below. With this update, these kinds of long URLs/words will be broken as it's shown in the second screenshot.

Before;
![screen shot 2017-02-15 at 11 25 19](https://cloud.githubusercontent.com/assets/6985467/22970177/76ac49fa-f371-11e6-8b1c-bdfc40b12f9d.png)

After;
![screen shot 2017-02-15 at 11 24 19](https://cloud.githubusercontent.com/assets/6985467/22970150/56f49ab8-f371-11e6-9f27-df41d5b16ae0.png)
