### PR TITLE
Break long URLs and align text right for info popup in viewer

### DIFF
--- a/flat/style/flat.viewer.css
+++ b/flat/style/flat.viewer.css
@@ -22,13 +22,13 @@ span.ab>span, span.ab>span.abc>span { /*items/rows in annotation box*/
     display: block;
     margin-right: 4px;
 }
-span.ab span.pos{ 
+span.ab span.pos{
     color: #5c6280;
 }
-span.ab span.lemma{ 
+span.ab span.lemma{
     color: #7a805c;
 }
-span.ab span.su{ 
+span.ab span.su{
     color: #528ed2;
 }
 span.ab span.dependency {
@@ -154,9 +154,10 @@ div#info {
 }
 div#info table {
     width: 100%;
+    table-layout:fixed;
 }
 div#info th {
-    width: 39%;
+    width: 50%;
     font-weight: bold;
     vertical-align: top;
 }
@@ -167,10 +168,13 @@ div#info th span.setname {
     font-weight: normal;
     font-size: 8pt;
     padding-left: 10px;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 }
 div#info td {
-    width: 59%;
+    width: 49%;
     font-style: italic;
+    text-align: right;
 }
 .class {
     color: #3323cd;
@@ -253,7 +257,7 @@ div#search{
     display: none;
     width: 520px;
     padding: 10px;
-    background: #cdcdcd; 
+    background: #cdcdcd;
     color: #333;
     border: #30677c 1px solid;
     border-radius: 15px;
@@ -317,7 +321,7 @@ div#treeview, div#viewer {
     position: absolute;
     display: none;
     padding: 10px;
-    background: #cdcdcd; 
+    background: #cdcdcd;
     color: #333;
     border: #30677c 1px solid;
     border-radius: 15px;


### PR DESCRIPTION
The long URLs was overflowing in the info popup and causing difficulties to read the actual contents. Additionally, I aligned the content info to the right to make it look tidier.

Before;
![screen shot 2017-02-15 at 23 31 54](https://cloud.githubusercontent.com/assets/6985467/22998469/334cb4a4-f3d7-11e6-9a0f-b279f91c3035.png)

After;
![screen shot 2017-02-15 at 23 19 22](https://cloud.githubusercontent.com/assets/6985467/22998477/387076b4-f3d7-11e6-81c1-cf118af4346f.png)
